### PR TITLE
Don't set Content-Length property explicitly

### DIFF
--- a/src/main/java/com/github/oohira/intercom/Intercom.java
+++ b/src/main/java/com/github/oohira/intercom/Intercom.java
@@ -534,7 +534,7 @@ public class Intercom {
             if (method.equals("POST") || method.equals("PUT") || method.equals("DELETE")) {
                 http.setDoOutput(true);
                 http.setRequestProperty("Content-Type", "application/json");
-                http.setRequestProperty("Content-Length", String.valueOf(body));
+                //NOTE: Content-Length is automatically set by Java HTTP library.
             }
             http.connect();
 


### PR DESCRIPTION
As @maxkremer pointed out, there was a potential bug to set whole request contents to Content-Length property instead of the length.

> Shouldnt this be String.valueOf(body).length() ? You're essentially putting all of the content in the content-length header

However, for good or bad, I found it does not have a impact for current users because HttpURLConnection.setRequestProperty() doesn't allow us to set Content-Length explicitly.

The wrong value (i.e. String.valueOf(body)) was just ignored. Of course, any other values are also ignored.
